### PR TITLE
Add more CI steps, address lint/gosec issues flagged

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,13 @@
 name: go test
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go-version: [1.14.x, 1.15.x]
@@ -25,6 +28,22 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
+
+      - name: Go fmt check
+        run: diff -u <(echo -n) <(gofmt -d ./)
+
+      - name: Go lint check
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+
+      - name: Go mod tidy check
+        run: |
+          go mod tidy
+          git diff --exit-code
+
+      - name: Run gosec security scanner
+        uses: securego/gosec@master
 
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,17 @@ on:
       - main
 
 jobs:
+  gosec:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run gosec security scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...
+
   test:
     runs-on: ubuntu-20.04
     strategy:
@@ -13,9 +24,6 @@ jobs:
         go-version: [1.14.x, 1.15.x]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
       - name: Cache build dependencies
         uses: actions/cache@v2
         with:
@@ -41,11 +49,6 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code
-
-      - name: Run gosec security scanner
-        uses: securego/gosec@master
-        with:
-          args: ./...
 
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Run gosec security scanner
         uses: securego/gosec@master
+        with:
+          args: ./...
 
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,17 @@ jobs:
         with:
           args: ./...
 
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Go lint check
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+
   test:
     runs-on: ubuntu-20.04
     strategy:
@@ -42,11 +53,6 @@ jobs:
 
       - name: Go fmt check
         run: diff -u <(echo -n) <(gofmt -d ./)
-
-      - name: Go lint check
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.29
 
       - name: Go mod tidy check
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,9 @@ jobs:
         go-version: [1.14.x, 1.15.x]
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       - name: Cache build dependencies
         uses: actions/cache@v2
         with:

--- a/api/ability.go
+++ b/api/ability.go
@@ -50,7 +50,7 @@ func (a *Abilities) GetAbilities(ctx context.Context) (*[]Ability, error) {
 
 	var err error
 	resp := []Ability{}
-	url := fmt.Sprintf("%s", a.urlPrefix)
+	url := a.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Ability{}

--- a/api/calendar.go
+++ b/api/calendar.go
@@ -86,7 +86,7 @@ func (c *Calendars) GetCalendars(ctx context.Context) (*[]Calendar, error) {
 
 	var err error
 	resp := []Calendar{}
-	url := fmt.Sprintf("%s", c.urlPrefix)
+	url := c.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Calendar{}

--- a/api/campaign.go
+++ b/api/campaign.go
@@ -8,7 +8,8 @@ import (
 
 // Campaigns is used to query the campaigns endpoints
 type Campaigns struct {
-	client *Client
+	client    *Client
+	urlPrefix string
 }
 
 // Campaign is used to serialize a campaign object
@@ -45,7 +46,10 @@ type CampaignUser struct {
 
 // Campaigns returns a handle on the campaigns endpoints
 func (c *Client) Campaigns() *Campaigns {
-	return &Campaigns{client: c}
+	return &Campaigns{
+		client:    c,
+		urlPrefix: "/campaigns",
+	}
 }
 
 // GetCampaigns can return information about all campaigns
@@ -53,7 +57,7 @@ func (c *Campaigns) GetCampaigns(ctx context.Context) (*[]Campaign, error) {
 
 	var err error
 	resp := []Campaign{}
-	url := "/campaigns"
+	url := c.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Campaign{}
@@ -68,6 +72,6 @@ func (c *Campaigns) GetCampaigns(ctx context.Context) (*[]Campaign, error) {
 func (c *Campaigns) GetCampaign(ctx context.Context, id int) (*Campaign, error) {
 
 	resp := Campaign{}
-	_, err := c.client.makeRequest(ctx, "GET", fmt.Sprintf("/campaigns/%d", id), &resp)
+	_, err := c.client.makeRequest(ctx, "GET", fmt.Sprintf("/%s/%d", c.urlPrefix, id), &resp)
 	return &resp, err
 }

--- a/api/character.go
+++ b/api/character.go
@@ -67,7 +67,7 @@ func (c *Characters) GetCharacters(ctx context.Context) (*[]Character, error) {
 
 	var err error
 	resp := []Character{}
-	url := fmt.Sprintf("%s", c.urlPrefix)
+	url := c.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		fmt.Println("Getting", url)

--- a/api/client.go
+++ b/api/client.go
@@ -137,7 +137,7 @@ func (c *Client) makeRequest(ctx context.Context, method string, endpoint string
 	}
 
 	// Bail out for non-JSON responses
-	respContentHeader := resp.Header.Get(http.CanonicalHeaderKey("Content-Type"))
+	respContentHeader := resp.Header.Get("Content-Type")
 	if !strings.Contains(strings.ToLower(respContentHeader), "application/json") {
 		return "", fmt.Errorf("Non-JSON response: %s, Content-Type: %s", resp.Status, respContentHeader)
 	}

--- a/api/event.go
+++ b/api/event.go
@@ -50,7 +50,7 @@ func (e *Events) GetEvents(ctx context.Context) (*[]Event, error) {
 
 	var err error
 	resp := []Event{}
-	url := fmt.Sprintf("%s", e.urlPrefix)
+	url := e.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Event{}

--- a/api/family.go
+++ b/api/family.go
@@ -51,7 +51,7 @@ func (f *Families) GetFamilies(ctx context.Context) (*[]Family, error) {
 
 	var err error
 	resp := []Family{}
-	url := fmt.Sprintf("%s", f.urlPrefix)
+	url := f.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Family{}

--- a/api/item.go
+++ b/api/item.go
@@ -52,7 +52,7 @@ func (i *Items) GetItems(ctx context.Context) (*[]Item, error) {
 
 	var err error
 	resp := []Item{}
-	url := fmt.Sprintf("%s", i.urlPrefix)
+	url := i.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Item{}

--- a/api/journal.go
+++ b/api/journal.go
@@ -50,7 +50,7 @@ func (j *Journals) GetJournals(ctx context.Context) (*[]Journal, error) {
 
 	var err error
 	resp := []Journal{}
-	url := fmt.Sprintf("%s", j.urlPrefix)
+	url := j.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Journal{}

--- a/api/location.go
+++ b/api/location.go
@@ -67,7 +67,7 @@ func (l *Locations) GetLocations(ctx context.Context) (*[]Location, error) {
 
 	var err error
 	resp := []Location{}
-	url := fmt.Sprintf("%s", l.urlPrefix)
+	url := l.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Location{}

--- a/api/map.go
+++ b/api/map.go
@@ -109,7 +109,7 @@ func (m *Maps) GetMaps(ctx context.Context) (*[]Map, error) {
 
 	var err error
 	resp := []Map{}
-	url := fmt.Sprintf("%s", m.urlPrefix)
+	url := m.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Map{}

--- a/api/note.go
+++ b/api/note.go
@@ -50,7 +50,7 @@ func (n *Notes) GetNotes(ctx context.Context) (*[]Note, error) {
 
 	var err error
 	resp := []Note{}
-	url := fmt.Sprintf("%s", n.urlPrefix)
+	url := n.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Note{}

--- a/api/organisation.go
+++ b/api/organisation.go
@@ -51,7 +51,7 @@ func (o *Organisations) GetOrganisations(ctx context.Context) (*[]Organisation, 
 
 	var err error
 	resp := []Organisation{}
-	url := fmt.Sprintf("%s", o.urlPrefix)
+	url := o.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Organisation{}

--- a/api/quest.go
+++ b/api/quest.go
@@ -106,7 +106,7 @@ func (q *Quests) GetQuests(ctx context.Context) (*[]Quest, error) {
 
 	var err error
 	resp := []Quest{}
-	url := fmt.Sprintf("%s", q.urlPrefix)
+	url := q.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Quest{}

--- a/api/race.go
+++ b/api/race.go
@@ -49,7 +49,7 @@ func (r *Races) GetRaces(ctx context.Context) (*[]Race, error) {
 
 	var err error
 	resp := []Race{}
-	url := fmt.Sprintf("%s", r.urlPrefix)
+	url := r.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Race{}

--- a/api/tag.go
+++ b/api/tag.go
@@ -51,7 +51,7 @@ func (t *Tags) GetTags(ctx context.Context) (*[]Tag, error) {
 
 	var err error
 	resp := []Tag{}
-	url := fmt.Sprintf("%s", t.urlPrefix)
+	url := t.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Tag{}

--- a/api/timeline.go
+++ b/api/timeline.go
@@ -58,7 +58,7 @@ func (t *Timelines) GetTimelines(ctx context.Context) (*[]Timeline, error) {
 
 	var err error
 	resp := []Timeline{}
-	url := fmt.Sprintf("%s", t.urlPrefix)
+	url := t.urlPrefix
 
 	for len(url) > 0 && err == nil {
 		page := []Timeline{}


### PR DESCRIPTION
PR adds the following tests:

* gofmt check
* [golangci-lint](https://github.com/golangci/golangci-lint) check
* go mod tidy check
* gosec security scanner

There are a handful of updates to the API client as well based on the findings of these checks.