### PR TITLE
Add client self-rate-limiting

### DIFF
--- a/api/character.go
+++ b/api/character.go
@@ -70,7 +70,6 @@ func (c *Characters) GetCharacters(ctx context.Context) (*[]Character, error) {
 	url := c.urlPrefix
 
 	for len(url) > 0 && err == nil {
-		fmt.Println("Getting", url)
 		page := []Character{}
 		url, err = c.client.makeRequest(ctx, "GET", url, &page)
 		resp = append(resp, page...)


### PR DESCRIPTION
The Kanka API throttles requests to 30 per minute (or 90 per minute for subscribers). This client de-paginates results though (it's convenient!) which means a request of `client.Characters(campaignID).GetCharacters(ctx)` will result in multiple API calls if there are more than 15 characters in the campaign. It would take only a few `Get...` functions to exceed this limit for a campaign with a lot of entities.

This PR adds a client-side rate-limiter that tries to stay below this limit by constructing a buffered channel with a length equal to the maximum number of requests per minute (so, 30 by default). Before each request is dispatched, a stub message is sent to the channel, and then dequeue it 1 minute after a response is received. This means that 30 messages can be sent in quick succession without any slow-down, but this will cause the channel to be filled and block a 31st request until a minute has passed since the first request.

The rate limit is configurable (such as for subscribers) and even the "length" of a minute is configurable for the sake of making tests pass faster, though the latter should never be used except for the sake of writing tests.