### PR TITLE
Add search api

### DIFF
--- a/api/mocks/GET/campaigns/1/search/tyr.json
+++ b/api/mocks/GET/campaigns/1/search/tyr.json
@@ -1,0 +1,19 @@
+    {
+        "data": [
+            {
+                "id": 1,
+                "entity_id": 5,
+                "name": "Tyrion Lannister",
+                "image": "https://example.com/image.png",
+                "image_thumb": "https://example.com/image_thumb.png",
+                "type": "character",
+                "tooltip": "Lorem Ipsum",
+                "url": "https://example.com/campaign/1/characters/1",
+                "is_private": true,
+                "created_at":  "2019-01-30T00:01:44.000000Z",
+                "created_by": 1,
+                "updated_at":  "2019-08-29T13:48:54.000000Z",
+                "updated_by": 1
+            }
+        ]
+    }

--- a/api/search.go
+++ b/api/search.go
@@ -1,0 +1,64 @@
+package kanka
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Searches is used to query the search endpoint
+type Searches struct {
+	client     *Client
+	campaignID int
+	urlPrefix  string
+}
+
+// SearchResult is used to serialize responses from the search endpoint
+type SearchResult struct {
+	ID        int  `json:"id"`
+	EntityID  int  `json:"entity_id"`
+	IsPrivate bool `json:"is_private"`
+
+	Name    string `json:"name"`
+	ToolTip string `json:"tooltip"`
+	Type    string `json:"type"`
+	URL     string `json:"url"`
+
+	Image          string `json:"image"`
+	ImageThumb     string `json:"image_thumb"`
+	HasCustomImage bool   `json:"has_custom_image"`
+
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy int       `json:"created_by"`
+	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedBy int       `json:"updated_by"`
+}
+
+// Searches returns a handle on the search endpoint
+func (c *Client) Searches(campaignID int) *Searches {
+	return &Searches{
+		client:     c,
+		campaignID: campaignID,
+		urlPrefix:  fmt.Sprintf("/campaigns/%d/search", campaignID),
+	}
+}
+
+// Search returns one or more results on a search request
+func (s *Searches) Search(ctx context.Context, searchTerm string) (*[]SearchResult, error) {
+
+	// Need to URL encode spaces, etc; url.QueryEscape produces `+` for spaces which appears to be incompatible with kanka
+	encodedTerm := &url.URL{Path: searchTerm}
+
+	var err error
+	resp := []SearchResult{}
+	url := fmt.Sprintf("%s/%s", s.urlPrefix, encodedTerm.String())
+
+	for len(url) > 0 && err == nil {
+		page := []SearchResult{}
+		url, err = s.client.makeRequest(ctx, "GET", url, &page)
+		resp = append(resp, page...)
+	}
+
+	return &resp, err
+}

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -1,0 +1,53 @@
+package kanka
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearches(t *testing.T) {
+
+	client := NewClient(DefaultConfig())
+	c := client.Searches(1)
+
+	assert.Equal(t, client, c.client)
+	assert.Equal(t, "/campaigns/1/search", c.urlPrefix)
+}
+
+func TestSearch(t *testing.T) {
+
+	testServer, config := mockTestServer()
+	defer testServer.Close()
+	client := NewClient(config)
+	ctx := context.Background()
+
+	results, err := client.Searches(1).Search(ctx, "tyr")
+
+	if assert.NoError(t, err) {
+		assert.Len(t, *results, 1)
+
+		// Main search result assertions
+		r := (*results)[0]
+		assert.Equal(t, 1, r.ID)
+		assert.Equal(t, 5, r.EntityID)
+		assert.Equal(t, true, r.IsPrivate)
+		assert.Equal(t, "Tyrion Lannister", r.Name)
+		assert.Equal(t, "Lorem Ipsum", r.ToolTip)
+		assert.Equal(t, "character", r.Type)
+		assert.Equal(t, "https://example.com/campaign/1/characters/1", r.URL)
+		assert.Equal(t, "https://example.com/image.png", r.Image)
+		assert.Equal(t, "https://example.com/image_thumb.png", r.ImageThumb)
+		assert.Equal(t, false, r.HasCustomImage)
+
+		// Date & time assertions
+		created := time.Date(2019, time.January, 30, 00, 01, 44, 0, time.UTC)
+		updated := time.Date(2019, time.August, 29, 13, 48, 54, 0, time.UTC)
+		assert.Equal(t, created, r.CreatedAt)
+		assert.Equal(t, updated, r.UpdatedAt)
+		assert.Equal(t, 1, r.CreatedBy)
+		assert.Equal(t, 1, r.UpdatedBy)
+	}
+}


### PR DESCRIPTION
PR adds the search API. A couple of wrinkles:

1. The returned URL won't be usable:

```
 returned URL: https://example.com/campaign/1/characters/1
browsable URL: https://example.com/en-US/campaign/1/characters/1
```

This library should probably just accurately return the responses and only intervene in extreme cases (e.g. enforcing https protocol on pagination) so it will be up to library consumers to rewrite the returned URL into a usable form. That's not terrible though, since there are multiple ways to re-write the base of the returned URL:

* example.com/ -> example.com/en-US/ (useful for opening result in browser)
* example.com/ -> example.com/api/1.0/ (useful for making a follow-up API call)

2. The second wrinkle is that the tooltip will be raw, which means if it contains links to other entities, it will look a bit goofy. For example:

```
"tooltip": "Hailing from the city of [location:1234]..."
```

The next PR will likely be a convenience method to resolve `[location:1234]` and other links into the entity's name, but by default it will return the string as-is.