### PR TITLE
Link resolution

### DIFF
--- a/api/ability.go
+++ b/api/ability.go
@@ -36,6 +36,13 @@ type Ability struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("ability", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		ability, _ := client.Abilities(campaignID).GetAbility(ctx, entityID)
+		return ability.Name
+	})
+}
+
 // Abilities returns a handle of the abilities endpoint
 func (c *Client) Abilities(campaignID int) *Abilities {
 	return &Abilities{

--- a/api/calendar.go
+++ b/api/calendar.go
@@ -72,6 +72,13 @@ type Season struct {
 	Day   int    `json:"day"`
 }
 
+func init() {
+	addKnownLinkType("calendar", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		calendar, _ := client.Calendars(campaignID).GetCalendar(ctx, entityID)
+		return calendar.Name
+	})
+}
+
 // Calendars returns a handle of the calendars endpoint
 func (c *Client) Calendars(campaignID int) *Calendars {
 	return &Calendars{

--- a/api/character.go
+++ b/api/character.go
@@ -53,6 +53,13 @@ type Trait struct {
 	DefaultOrder int    `json:"default_order"`
 }
 
+func init() {
+	addKnownLinkType("character", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		character, _ := client.Characters(campaignID).GetCharacter(ctx, entityID)
+		return character.Name
+	})
+}
+
 // Characters returns a handle on the characters endpoint
 func (c *Client) Characters(campaignID int) *Characters {
 	return &Characters{

--- a/api/event.go
+++ b/api/event.go
@@ -36,6 +36,13 @@ type Event struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("event", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		event, _ := client.Events(campaignID).GetEvent(ctx, entityID)
+		return event.Name
+	})
+}
+
 // Events returns a handle of the events endpoint
 func (c *Client) Events(campaignID int) *Events {
 	return &Events{

--- a/api/family.go
+++ b/api/family.go
@@ -37,6 +37,13 @@ type Family struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("family", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		family, _ := client.Families(campaignID).GetFamily(ctx, entityID)
+		return family.Name
+	})
+}
+
 // Families returns a handle on the families endpoint
 func (c *Client) Families(campaignID int) *Families {
 	return &Families{

--- a/api/item.go
+++ b/api/item.go
@@ -38,6 +38,13 @@ type Item struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("item", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		item, _ := client.Items(campaignID).GetItem(ctx, entityID)
+		return item.Name
+	})
+}
+
 // Items returns a handle of the items endpoint
 func (c *Client) Items(campaignID int) *Items {
 	return &Items{

--- a/api/journal.go
+++ b/api/journal.go
@@ -36,6 +36,13 @@ type Journal struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("journal", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		journal, _ := client.Journals(campaignID).GetJournal(ctx, entityID)
+		return journal.Name
+	})
+}
+
 // Journals returns a handle of the journals endpoint
 func (c *Client) Journals(campaignID int) *Journals {
 	return &Journals{

--- a/api/location.go
+++ b/api/location.go
@@ -53,6 +53,13 @@ type MapPoint struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+func init() {
+	addKnownLinkType("location", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		location, _ := client.Locations(campaignID).GetLocation(ctx, entityID)
+		return location.Name
+	})
+}
+
 // Locations returns a handle on the locations endpoints
 func (c *Client) Locations(campaignID int) *Locations {
 	return &Locations{

--- a/api/map.go
+++ b/api/map.go
@@ -95,6 +95,13 @@ type MapGroup struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("map", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		m, _ := client.Maps(campaignID).GetMap(ctx, entityID)
+		return m.Name
+	})
+}
+
 // Maps returns a handle of the maps endpoint
 func (c *Client) Maps(campaignID int) *Maps {
 	return &Maps{

--- a/api/note.go
+++ b/api/note.go
@@ -36,6 +36,13 @@ type Note struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("note", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		note, _ := client.Notes(campaignID).GetNote(ctx, entityID)
+		return note.Name
+	})
+}
+
 // Notes returns a handle of the notes endpoint
 func (c *Client) Notes(campaignID int) *Notes {
 	return &Notes{

--- a/api/organisation.go
+++ b/api/organisation.go
@@ -37,6 +37,13 @@ type Organisation struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("organisation", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		organisation, _ := client.Organisations(campaignID).GetOrganisation(ctx, entityID)
+		return organisation.Name
+	})
+}
+
 // Organisations returns a handle of the organisations endpoint
 func (c *Client) Organisations(campaignID int) *Organisations {
 	return &Organisations{

--- a/api/quest.go
+++ b/api/quest.go
@@ -92,6 +92,13 @@ type QuestOrganisation struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("quest", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		quest, _ := client.Quests(campaignID).GetQuest(ctx, entityID)
+		return quest.Name
+	})
+}
+
 // Quests returns a handle of the quests endpoint
 func (c *Client) Quests(campaignID int) *Quests {
 	return &Quests{

--- a/api/race.go
+++ b/api/race.go
@@ -35,6 +35,13 @@ type Race struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("race", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		race, _ := client.Races(campaignID).GetRace(ctx, entityID)
+		return race.Name
+	})
+}
+
 // Races returns a handle of the races endpoint
 func (c *Client) Races(campaignID int) *Races {
 	return &Races{

--- a/api/search.go
+++ b/api/search.go
@@ -72,9 +72,9 @@ func (s *Searches) Search(ctx context.Context, searchTerm string) (*[]SearchResu
 	return &resp, err
 }
 
-// ResolveLinks attempts to lookup and resolve the names of linked entities in a string.
+// ResolveLinksToText attempts to lookup and resolve the names of linked entities in a string.
 // E.g. attempt to resolve "Hailing from the city of [location:1234]" to "Hailing from the city of Neverwinter"
-func (s *Searches) ResolveLinks(ctx context.Context, rawString string) string {
+func (s *Searches) ResolveLinksToText(ctx context.Context, rawString string) string {
 
 	// Extract [alpha:digit] instances from string
 	links := linkRe.FindAllString(rawString, -1)

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -52,7 +52,7 @@ func TestSearch(t *testing.T) {
 	}
 }
 
-func TestResolveLinks(t *testing.T) {
+func TestResolveLinksToText(t *testing.T) {
 
 	testServer, config := mockTestServer()
 	defer testServer.Close()
@@ -61,18 +61,13 @@ func TestResolveLinks(t *testing.T) {
 
 	// Test successful resolution
 	rawTestString := "[character:1] hails from [location:1]"
-	resolvedTestString, err := client.Searches(1).ResolveLinks(ctx, rawTestString)
+	resolvedTestString := client.Searches(1).ResolveLinksToText(ctx, rawTestString)
 
-	if assert.NoError(t, err) {
-		assert.Equal(t, "Jonathan Green hails from Mordor", resolvedTestString)
-	}
+	assert.Equal(t, "Jonathan Green hails from Mordor", resolvedTestString)
 
 	// Test unsuccessful resolution
 	rawTestString = "[character:100] hails from [location:1]"
-	resolvedTestString, err = client.Searches(1).ResolveLinks(ctx, rawTestString)
+	resolvedTestString = client.Searches(1).ResolveLinksToText(ctx, rawTestString)
 
-	if assert.NoError(t, err) {
-		assert.Equal(t, "[character:100] hails from Mordor", resolvedTestString)
-	}
-
+	assert.Equal(t, "[character:100] hails from Mordor", resolvedTestString)
 }

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -51,3 +51,28 @@ func TestSearch(t *testing.T) {
 		assert.Equal(t, 1, r.UpdatedBy)
 	}
 }
+
+func TestResolveLinks(t *testing.T) {
+
+	testServer, config := mockTestServer()
+	defer testServer.Close()
+	client := NewClient(config)
+	ctx := context.Background()
+
+	// Test successful resolution
+	rawTestString := "[character:1] hails from [location:1]"
+	resolvedTestString, err := client.Searches(1).ResolveLinks(ctx, rawTestString)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "Jonathan Green hails from Mordor", resolvedTestString)
+	}
+
+	// Test unsuccessful resolution
+	rawTestString = "[character:100] hails from [location:1]"
+	resolvedTestString, err = client.Searches(1).ResolveLinks(ctx, rawTestString)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "[character:100] hails from Mordor", resolvedTestString)
+	}
+
+}

--- a/api/tag.go
+++ b/api/tag.go
@@ -37,6 +37,13 @@ type Tag struct {
 	UpdatedBy int       `json:"updated_by"`
 }
 
+func init() {
+	addKnownLinkType("tag", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		tag, _ := client.Tags(campaignID).GetTag(ctx, entityID)
+		return tag.Name
+	})
+}
+
 // Tags returns a handle of the tags endpoint
 func (c *Client) Tags(campaignID int) *Tags {
 	return &Tags{

--- a/api/timeline.go
+++ b/api/timeline.go
@@ -44,6 +44,13 @@ type Era struct {
 	EndYear      int    `json:"end_year"`
 }
 
+func init() {
+	addKnownLinkType("timeline", func(ctx context.Context, client *Client, campaignID int, entityID int) string {
+		timeline, _ := client.Timelines(campaignID).GetTimeline(ctx, entityID)
+		return timeline.Name
+	})
+}
+
 // Timelines returns a handle of the timelines endpoint
 func (c *Client) Timelines(campaignID int) *Timelines {
 	return &Timelines{


### PR DESCRIPTION
When using the search API, results can return a tooltip with inline links to other entities, e.g.:

```
"tooltip": "Hailing from the city of [location:1234]..."
```

This PR allows you to take the tooltip value and run it through `ResolveLinksToText` which will rewrite the string with the entity's name. This is done making additional API calls, and as the function name hints, it is strictly to text. Perhaps we could write a different (and slightly smarter) version that returned the whole entity record so that it were possible to make clickable links, but that's an exercise for another day.

To make this work, all entity types should register themselves in the entity source file's `init` function. For example: in locations.go, we register a known type that effectively says "Hey if you get a `[location:1234]` link, then use this function to resolve its name."