### PR TITLE
Support go 1.16 and 1.17 in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,10 @@ jobs:
           version: v1.29
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.16.x, 1.17.x]
 
     steps:
       - name: Checkout code
@@ -53,11 +53,6 @@ jobs:
 
       - name: Go fmt check
         run: diff -u <(echo -n) <(gofmt -d ./)
-
-      - name: Go mod tidy check
-        run: |
-          go mod tidy
-          git diff --exit-code
 
       - name: Run tests
         run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/byronwolfman/kanka-client
 
-go 1.15
+go 1.16
 
 require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
This PR:

* Bumps go.mod version to 1.16
* Adds support for go 1.16 and 1.17 in tests
* Removes support for previous versions in tests
* Removes `go mod tidy` check since go 1.16 and 1.17 produce different results
* Unpins ubuntu executor; we're ok to live on the edge